### PR TITLE
fix: Conflict resolution.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 qtbase-opensource-src (5.15.7-1+dde) unstable; urgency=medium
 
   * New upstream release (5.15.7).
+  * Resolve libqtcore4 conflict with libqt5core5a.
 
  -- Duan Ting <duanting@uniontech.com>  Thu, 03 Nov 2022 14:43:40 +0800
 

--- a/debian/libqt5core5a.links
+++ b/debian/libqt5core5a.links
@@ -1,1 +1,2 @@
-usr/share/qtchooser/qt5-${DEB_HOST_MULTIARCH}.conf usr/lib/${DEB_HOST_MULTIARCH}/qt-default/qtchooser/default.conf
+#Resolve libqtcore4 conflict with libqt5core5a.
+#usr/share/qtchooser/qt5-${DEB_HOST_MULTIARCH}.conf usr/lib/${DEB_HOST_MULTIARCH}/qt-default/qtchooser/default.conf


### PR DESCRIPTION
deepin qt4 and qt5 exit at the same time,
resolve libqtcore4 conflict with libqt5core5a.

log: Resolve libqtcore4 conflict with libqt5core5a.