### PR TITLE
fix: Revert "xcb: implement missing bits from ICCCM 4.1.4 WM_STATE ha…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,13 @@
 qtbase-opensource-src (5.15.7.1-1+dde) UNRELEASED; urgency=medium
 
+  [ Lu YaNing ]
   * Install QtXcbQpa private headers.
   * dbus: add filter hook
     -- QTBUG-108092-add-filter-hook.patch
+
+  [ Tang Haixiang ]
+  * Revert "xcb: implement missing bits from ICCCM 4.1.4 WM_STATE handling"
+    -- QTBUG-101347-revert-xcb-implement-missing-bits-form-icccm414-WM_STATE-handling.patch
 
  -- Lu YaNing <luyaning@uniontech.com>  Mon, 05 Dec 2022 13:25:17 +0800
 

--- a/debian/patches/QTBUG-101347-revert-xcb-implement-missing-bits-form-icccm414-WM_STATE-handling.patch
+++ b/debian/patches/QTBUG-101347-revert-xcb-implement-missing-bits-form-icccm414-WM_STATE-handling.patch
@@ -1,0 +1,243 @@
+Author: Tang Haixiang <tanghaixiang@uniontech.com>
+Date:   Dec Tue 06 14:09:12 2022 +0800
+Subject: Revert "xcb: implement missing bits from ICCCM 4.1.4 WM_STATE handling"
+Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/401815
+
+---
+
+Index: qtbase-opensource-src/src/plugins/platforms/xcb/qxcbwindow.cpp
+===================================================================
+--- qtbase-opensource-src.orig/src/plugins/platforms/xcb/qxcbwindow.cpp
++++ qtbase-opensource-src/src/plugins/platforms/xcb/qxcbwindow.cpp
+@@ -564,11 +564,6 @@ void QXcbWindow::setGeometry(const QRect
+ {
+     QPlatformWindow::setGeometry(rect);
+ 
+-    if (shouldDeferTask(Task::SetGeometry)) {
+-        m_deferredGeometry = rect;
+-        return;
+-    }
+-
+     propagateSizeHints();
+ 
+     QXcbScreen *currentScreen = xcbScreen();
+@@ -693,9 +688,6 @@ void QXcbWindow::setVisible(bool visible
+ 
+ void QXcbWindow::show()
+ {
+-    if (shouldDeferTask(Task::Map))
+-        return;
+-
+     if (window()->isTopLevel()) {
+ 
+         // update WM_NORMAL_HINTS
+@@ -746,10 +738,6 @@ void QXcbWindow::show()
+ 
+ void QXcbWindow::hide()
+ {
+-    if (shouldDeferTask(Task::Unmap))
+-        return;
+-
+-    m_wmStateValid = false;
+     xcb_unmap_window(xcb_connection(), m_window);
+ 
+     // send synthetic UnmapNotify event according to icccm 4.1.4
+@@ -909,9 +897,6 @@ QXcbWindow::NetWmStates QXcbWindow::netW
+ 
+ void QXcbWindow::setWindowFlags(Qt::WindowFlags flags)
+ {
+-    if (shouldDeferTask(Task::SetWindowFlags))
+-        return;
+-
+     Qt::WindowType type = static_cast<Qt::WindowType>(int(flags & Qt::WindowType_Mask));
+ 
+     if (type == Qt::ToolTip)
+@@ -941,8 +926,6 @@ void QXcbWindow::setWindowFlags(Qt::Wind
+ 
+     setTransparentForMouseEvents(flags & Qt::WindowTransparentForInput);
+     updateDoesNotAcceptFocus(flags & Qt::WindowDoesNotAcceptFocus);
+-
+-    m_isWmManagedWindow = !(flags & Qt::X11BypassWindowManagerHint);
+ }
+ 
+ void QXcbWindow::setMotifWmHints(Qt::WindowFlags flags)
+@@ -1142,9 +1125,6 @@ void QXcbWindow::setWindowState(Qt::Wind
+     if (state == m_windowState)
+         return;
+ 
+-    if (shouldDeferTask(Task::SetWindowState))
+-        return;
+-
+     // unset old state
+     if (m_windowState & Qt::WindowMinimized)
+         xcb_map_window(xcb_connection(), m_window);
+@@ -1900,10 +1880,6 @@ void QXcbWindow::handleUnmapNotifyEvent(
+     if (event->window == m_window) {
+         m_mapped = false;
+         QWindowSystemInterface::handleExposeEvent(window(), QRegion());
+-        if (!m_isWmManagedWindow) {
+-            m_wmStateValid = true;
+-            handleDeferredTasks();
+-        }
+     }
+ }
+ 
+@@ -2218,98 +2194,30 @@ void QXcbWindow::handleLeaveNotifyEvent(
+     handleLeaveNotifyEvent(event->root_x, event->root_y, event->mode, event->detail, event->time);
+ }
+ 
+-bool QXcbWindow::shouldDeferTask(Task task)
+-{
+-    if (m_wmStateValid)
+-        return false;
+-
+-    m_deferredTasks.append(task);
+-    return true;
+-}
+-
+-void QXcbWindow::handleDeferredTasks()
+-{
+-    Q_ASSERT(m_wmStateValid == true);
+-    if (m_deferredTasks.isEmpty())
+-        return;
+-
+-    bool map = false;
+-    bool unmap = false;
+-
+-    QVector<Task> tasks;
+-    for (auto taskIt = m_deferredTasks.rbegin(); taskIt != m_deferredTasks.rend(); ++taskIt) {
+-        if (!tasks.contains(*taskIt))
+-            tasks.prepend(*taskIt);
+-    }
+-
+-    for (Task task : tasks) {
+-        switch (task) {
+-        case Task::Map:
+-            map = true;
+-            unmap = false;
+-            break;
+-        case Task::Unmap:
+-            unmap = true;
+-            map = false;
+-            break;
+-        case Task::SetGeometry:
+-            setGeometry(m_deferredGeometry);
+-            break;
+-        case Task::SetWindowFlags:
+-            setWindowFlags(window()->flags());
+-            break;
+-        case Task::SetWindowState:
+-            setWindowState(window()->windowState());
+-            break;
+-        }
+-    }
+-    m_deferredTasks.clear();
+-
+-    if (map) {
+-        Q_ASSERT(unmap == false);
+-        show();
+-    }
+-    if (unmap) {
+-        Q_ASSERT(map == false);
+-        hide();
+-    }
+-}
+-
+ void QXcbWindow::handlePropertyNotifyEvent(const xcb_property_notify_event_t *event)
+ {
+     connection()->setTime(event->time);
+ 
+-    const bool wmStateChanged = event->atom == atom(QXcbAtom::WM_STATE);
+-    const bool netWmStateChanged = event->atom == atom(QXcbAtom::_NET_WM_STATE);
+-    if (netWmStateChanged || wmStateChanged) {
+-        if (wmStateChanged && !m_wmStateValid && m_isWmManagedWindow) {
+-            // ICCCM 4.1.4
+-            // Clients that want to re-use a client window (e.g. by mapping it again)
+-            // after withdrawing it must wait for the withdrawal to be complete before
+-            // proceeding. The preferred method for doing this is for clients to wait for
+-            // a window manager to update or remove the WM_STATE property.
+-            m_wmStateValid = true;
+-            handleDeferredTasks();
+-        }
+-        if (event->state == XCB_PROPERTY_DELETE)
++    const bool propertyDeleted = event->state == XCB_PROPERTY_DELETE;
++
++    if (event->atom == atom(QXcbAtom::_NET_WM_STATE) || event->atom == atom(QXcbAtom::WM_STATE)) {
++        if (propertyDeleted)
+             return;
+ 
+-        if (wmStateChanged) {
++        Qt::WindowStates newState = Qt::WindowNoState;
++
++        if (event->atom == atom(QXcbAtom::WM_STATE)) { // WM_STATE: Quick check for 'Minimize'.
+             auto reply = Q_XCB_REPLY(xcb_get_property, xcb_connection(),
+                                      0, m_window, atom(QXcbAtom::WM_STATE),
+                                      XCB_ATOM_ANY, 0, 1024);
+             if (reply && reply->format == 32 && reply->type == atom(QXcbAtom::WM_STATE)) {
+-                auto data = static_cast<const quint32 *>(xcb_get_property_value(reply.get()));
+-                if (reply->length != 0) {
+-                    const bool changedToWithdrawn = data[0] == XCB_ICCCM_WM_STATE_WITHDRAWN;
+-                    const bool changedToIconic = data[0] == XCB_ICCCM_WM_STATE_ICONIC;
+-                    m_minimized = changedToIconic || (changedToWithdrawn && m_minimized);
+-                }
++                const quint32 *data = (const quint32 *)xcb_get_property_value(reply.get());
++                if (reply->length != 0)
++                    m_minimized = (data[0] == XCB_ICCCM_WM_STATE_ICONIC
++                                   || (data[0] == XCB_ICCCM_WM_STATE_WITHDRAWN && m_minimized));
+             }
+         }
+ 
+-        // _NET_WM_STATE handling
+-        Qt::WindowStates newState = Qt::WindowNoState;
+         const NetWmStates states = netWmStates();
+         // _NET_WM_STATE_HIDDEN should be set by the Window Manager to indicate that a window would
+         // not be visible on the screen if its desktop/viewport were active and its coordinates were
+@@ -2331,6 +2239,7 @@ void QXcbWindow::handlePropertyNotifyEve
+             if ((m_windowState & Qt::WindowMinimized) && connection()->mouseGrabber() == this)
+                 connection()->setMouseGrabber(nullptr);
+         }
++        return;
+     } else if (event->atom == atom(QXcbAtom::_NET_FRAME_EXTENTS)) {
+         m_dirtyFrameMargins = true;
+     }
+Index: qtbase-opensource-src/src/plugins/platforms/xcb/qxcbwindow.h
+===================================================================
+--- qtbase-opensource-src.orig/src/plugins/platforms/xcb/qxcbwindow.h
++++ qtbase-opensource-src/src/plugins/platforms/xcb/qxcbwindow.h
+@@ -74,14 +74,6 @@ public:
+ 
+     Q_DECLARE_FLAGS(NetWmStates, NetWmState)
+ 
+-    enum Task {
+-        Map,
+-        Unmap,
+-        SetGeometry,
+-        SetWindowFlags,
+-        SetWindowState
+-    };
+-
+     QXcbWindow(QWindow *window);
+     ~QXcbWindow();
+ 
+@@ -151,9 +143,6 @@ public:
+ 
+     QXcbWindow *toWindow() override;
+ 
+-    bool shouldDeferTask(Task task);
+-    void handleDeferredTasks();
+-
+     void handleMouseEvent(xcb_timestamp_t time, const QPoint &local, const QPoint &global,
+                           Qt::KeyboardModifiers modifiers, QEvent::Type type, Qt::MouseEventSource source);
+ 
+@@ -292,11 +281,6 @@ protected:
+     int m_swapInterval = -1;
+ 
+     qreal m_sizeHintsScaleFactor = 1.0;
+-
+-    bool m_wmStateValid = true;
+-    QVector<Task> m_deferredTasks;
+-    bool m_isWmManagedWindow = true;
+-    QRect m_deferredGeometry;
+ };
+ 
+ class QXcbForeignWindow : public QXcbWindow

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -62,3 +62,5 @@ Avoid_adding_null-objects_to_the_icon_cache.patch
 QListView-pageDownUp-infinte-loop.patch
 QTBUG-92468-reconsider-cursor-drawing-textObject.patch
 QTBUG-108092-add-filter-hook.patch
+QTBUG-101347-revert-xcb-implement-missing-bits-form-icccm414-WM_STATE-handling.patch
+


### PR DESCRIPTION
…ndling"

It clears the duplicate show() and hide() too aggressive in handleDeferredTasks() and can cause visible states out of sync between qt and system(x11) when user switches visible on and off very frequently.

Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/401815

Bug: https://pms.uniontech.com/bug-view-175635.html

Log: App does not render properly after being minimized