### PR TITLE
fix: Add some error handling for the inotify file system watcher

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,11 @@
-qtbase-opensource-src (5.15.8-1+dde) UNRELEASED; urgency=medium
+qtbase-opensource-src (5.15.8-1+deepin1) UNRELEASED; urgency=medium
 
+  [ Lu YaNing ]
   * New upstream release (5.15.8).
+
+  [ Zhang TingAn ]
+  * Add some error handling for the inotify file system watcher
+    -- Add-some-error-handling-for-the-inotify-file-system-watcher.patch
 
  -- Lu YaNing <luyaning@uniontech.com>  Sat, 28 Jan 2023 16:18:43 +0800
 

--- a/debian/patches/Add-some-error-handling-for-the-inotify-file-system-watcher.patch
+++ b/debian/patches/Add-some-error-handling-for-the-inotify-file-system-watcher.patch
@@ -1,0 +1,21 @@
+Author: Zhang TingAn <zhangtingan@uniontech.com>
+Date:   Wed Oct 18 13:50:13 2023 +0800
+Subject: Add some error handling for the inotify file system watcher
+Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/329850
+https://codereview.qt-project.org/c/qt/qtbase/+/339537
+
+Index: qtbase-opensource-src/src/corelib/io/qfilesystemwatcher_inotify.cpp
+===================================================================
+--- qtbase-opensource-src.orig/src/corelib/io/qfilesystemwatcher_inotify.cpp
++++ qtbase-opensource-src/src/corelib/io/qfilesystemwatcher_inotify.cpp
+@@ -366,7 +366,9 @@ void QInotifyFileSystemWatcherEngine::re
+     // qDebug("QInotifyFileSystemWatcherEngine::readFromInotify");
+ 
+     int buffSize = 0;
+-    ioctl(inotifyFd, FIONREAD, (char *) &buffSize);
++    if(ioctl(inotifyFd, FIONREAD, (char *) &buffSize) == -1 || buffSize == 0)
++        return;
++
+     QVarLengthArray<char, 4096> buffer(buffSize);
+     buffSize = read(inotifyFd, buffer.data(), buffSize);
+     char *at = buffer.data();

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -62,3 +62,4 @@ QListView-pageDownUp-infinte-loop.patch
 QTBUG-92468-reconsider-cursor-drawing-textObject.patch
 QTBUG-108092-add-filter-hook.patch
 QTBUG-101347-revert-xcb-implement-missing-bits-form-icccm414-WM_STATE-handling.patch
+Add-some-error-handling-for-the-inotify-file-system-watcher.patch


### PR DESCRIPTION
In the readFromInotify() function, add a check whether the ioctl function is successful or not. In the case of failure, continuing to execute the following code would cause errors in the read function because there is no data in the buffer.

Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/329850 https://codereview.qt-project.org/c/qt/qtbase/+/339537

Bug: https://pms.uniontech.com/bug-view-220637.html