### PR TITLE
Fix: When minimizing a maximized window, the effect is abnormal.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-qtbase-opensource-src (5.15.8-1+deepin1) UNRELEASED; urgency=medium
+qtbase-opensource-src (5.15.8-1+deepin2) UNRELEASED; urgency=medium
 
   [ Lu YaNing ]
   * New upstream release (5.15.8).
@@ -6,6 +6,8 @@ qtbase-opensource-src (5.15.8-1+deepin1) UNRELEASED; urgency=medium
   [ Zhang TingAn ]
   * Add some error handling for the inotify file system watcher
     -- Add-some-error-handling-for-the-inotify-file-system-watcher.patch
+  * xcb: unset states and set new ones as need
+    -- xcb-unset-states-and-set-new-ones-as-need.patch
 
  -- Lu YaNing <luyaning@uniontech.com>  Sat, 28 Jan 2023 16:18:43 +0800
 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -63,3 +63,4 @@ QTBUG-92468-reconsider-cursor-drawing-textObject.patch
 QTBUG-108092-add-filter-hook.patch
 QTBUG-101347-revert-xcb-implement-missing-bits-form-icccm414-WM_STATE-handling.patch
 Add-some-error-handling-for-the-inotify-file-system-watcher.patch
+xcb-unset-states-and-set-new-ones-as-need.patch

--- a/debian/patches/xcb-unset-states-and-set-new-ones-as-need.patch
+++ b/debian/patches/xcb-unset-states-and-set-new-ones-as-need.patch
@@ -1,0 +1,50 @@
+Author: Zhang TingAn <zhangtingan@uniontech.com>
+Date:   Tue Nov 07 15:09:13 2023 +0800
+Subject: xcb: unset states and set new ones as need
+Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/504136
+
+Index: qtbase-opensource-src/src/plugins/platforms/xcb/qxcbwindow.cpp
+===================================================================
+--- qtbase-opensource-src.orig/src/plugins/platforms/xcb/qxcbwindow.cpp
++++ qtbase-opensource-src/src/plugins/platforms/xcb/qxcbwindow.cpp
+@@ -1125,18 +1125,21 @@ void QXcbWindow::setWindowState(Qt::Wind
+     if (state == m_windowState)
+         return;
+ 
++    Qt::WindowStates unsetState = m_windowState & ~state;
++    Qt::WindowStates newState =  state & ~m_windowState;
++
+     // unset old state
+-    if (m_windowState & Qt::WindowMinimized)
++    if (unsetState & Qt::WindowMinimized)
+         xcb_map_window(xcb_connection(), m_window);
+-    if (m_windowState & Qt::WindowMaximized)
++    if (unsetState & Qt::WindowMaximized)
+         setNetWmState(false,
+                       atom(QXcbAtom::_NET_WM_STATE_MAXIMIZED_HORZ),
+                       atom(QXcbAtom::_NET_WM_STATE_MAXIMIZED_VERT));
+-    if (m_windowState & Qt::WindowFullScreen)
++    if (unsetState & Qt::WindowFullScreen)
+         setNetWmState(false, atom(QXcbAtom::_NET_WM_STATE_FULLSCREEN));
+ 
+     // set new state
+-    if (state & Qt::WindowMinimized) {
++    if (newState & Qt::WindowMinimized) {
+         {
+             xcb_client_message_event_t event;
+ 
+@@ -1157,13 +1160,8 @@ void QXcbWindow::setWindowState(Qt::Wind
+         }
+         m_minimized = true;
+     }
+-    if (state & Qt::WindowMaximized)
+-        setNetWmState(true,
+-                      atom(QXcbAtom::_NET_WM_STATE_MAXIMIZED_HORZ),
+-                      atom(QXcbAtom::_NET_WM_STATE_MAXIMIZED_VERT));
+-    if (state & Qt::WindowFullScreen)
+-        setNetWmState(true, atom(QXcbAtom::_NET_WM_STATE_FULLSCREEN));
+ 
++    // set Maximized && FullScreen state if need
+     setNetWmState(state);
+ 
+     xcb_get_property_cookie_t cookie = xcb_icccm_get_wm_hints_unchecked(xcb_connection(), m_window);


### PR DESCRIPTION
fix: xcb: unset states and set new ones as need

Log: Should not unset all the old state and set the new ones. Only unset the state that needs to be unset.

If states changes from maximized to minimized, there is no need to unset the maximized state and set the maximized states again. (minimized and maximized can exist simultaneously :)

Bug: https://github.com/linuxdeepin/developer-center/issues/5627

upstream: https://codereview.qt-project.org/c/qt/qtbase/+/504136