### PR TITLE
fix: Architecture Avoid doing kill(-1) in QProcess destructor (loongarch64 Architecture)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qtbase-opensource-src (5.15.8-1+deepin4) unstable; urgency=medium
+
+  * Fix loongarch64 Architecture Avoid doing kill(-1) in QProcess destructor
+
+ -- LiChengGang <lichenggang@uniontech.com>  Tue, 30 Jan 2024 09:48:54 +0800
+
 qtbase-opensource-src (5.15.8-1+deepin3) unstable; urgency=medium
   
   [ LiChengGang ]

--- a/debian/patches/QTBUG-86285-Fix-kills-all-user-processes
+++ b/debian/patches/QTBUG-86285-Fix-kills-all-user-processes
@@ -1,0 +1,41 @@
+Description: <Avoid doing kill(-1) in QProcess destructor>
+ qtbase-opensource-src (5.15.8-1+deepin4) unstable; urgency=medium
+ .
+   [ LiChengGang ]
+   * Fix loongarch64 Architecture Avoid doing kill(-1) in QProcess destructor
+Author: LiChengGang <lichenggang@uniontech.com>
+
+---
+https://bugreports.qt.io/browse/QTBUG-86285
+https://codereview.qt-project.org/c/qt/qtbase/+/319522
+Last-Update: 2024-01-30
+
+--- qtbase-opensource-src-5.15.8.orig/src/corelib/io/qprocess_unix.cpp
++++ qtbase-opensource-src-5.15.8/src/corelib/io/qprocess_unix.cpp
+@@ -506,7 +506,7 @@ void QProcessPrivate::startProcess()
+     }
+ 
+     pid = Q_PID(childPid);
+-
++    Q_ASSERT(pid > 0);
+     // parent
+     // close the ends we don't use and make all pipes non-blocking
+     qt_safe_close(childStartedPipe[1]);
+@@ -696,7 +696,7 @@ void QProcessPrivate::terminateProcess()
+ #if defined (QPROCESS_DEBUG)
+     qDebug("QProcessPrivate::terminateProcess()");
+ #endif
+-    if (pid)
++    if (pid > 0) 
+         ::kill(pid_t(pid), SIGTERM);
+ }
+ 
+@@ -705,7 +705,7 @@ void QProcessPrivate::killProcess()
+ #if defined (QPROCESS_DEBUG)
+     qDebug("QProcessPrivate::killProcess()");
+ #endif
+-    if (pid)
++    if (pid > 0)
+         ::kill(pid_t(pid), SIGKILL);
+ }
+ 

--- a/debian/patches/loongarch.diff
+++ b/debian/patches/loongarch.diff
@@ -1,0 +1,41 @@
+Description: add support for LoongArch
+Origin: upstream, commits
+ https://code.qt.io/cgit/qt/qtbase.git/commit/?id=bdc16f086f1664b5
+ https://code.qt.io/cgit/qt/qtbase.git/commit/?id=0ab51dcc3c0cca0d
+Last-Update: 2024-01-30
+
+--- qtbase-opensource-src-5.15.8.orig/src/corelib/global/archdetect.cpp
++++ qtbase-opensource-src-5.15.8/src/corelib/global/archdetect.cpp
+@@ -59,6 +59,10 @@
+ #  define ARCH_PROCESSOR "x86_64"
+ #elif defined(Q_PROCESSOR_IA64)
+ #  define ARCH_PROCESSOR "ia64"
++#elif defined(Q_PROCESSOR_LOONGARCH_32)
++#  define ARCH_PROCESSOR "loongarch32"
++#elif defined(Q_PROCESSOR_LOONGARCH_64)
++#  define ARCH_PROCESSOR "loongarch64"
+ #elif defined(Q_PROCESSOR_MIPS_64)
+ #  define ARCH_PROCESSOR "mips64"
+ #elif defined(Q_PROCESSOR_MIPS)
+--- qtbase-opensource-src-5.15.8.orig/src/corelib/global/qprocessordetection.h
++++ qtbase-opensource-src-5.15.8/src/corelib/global/qprocessordetection.h
+@@ -227,6 +227,19 @@
+ #  define Q_PROCESSOR_IA64
+ #  define Q_PROCESSOR_WORDSIZE   8
+ // Q_BYTE_ORDER not defined, use endianness auto-detection
++ /*
+++    LoongArch family, known variants: 32- and 64-bit
+++
+++    LoongArch is little-endian.
+++*/
++#elif defined(__loongarch__)
++#  define Q_PROCESSOR_LOONGARCH
++#  if __loongarch_grlen == 64
++#    define Q_PROCESSOR_LOONGARCH_64
++#  else
++#    define Q_PROCESSOR_LOONGARCH_32
++#  endif
++#  define Q_BYTE_ORDER Q_LITTLE_ENDIAN
+ 
+ /*
+     MIPS family, known revisions: I, II, III, IV, 32, 64

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -65,3 +65,5 @@ QTBUG-101347-revert-xcb-implement-missing-bits-form-icccm414-WM_STATE-handling.p
 Add-some-error-handling-for-the-inotify-file-system-watcher.patch
 xcb-unset-states-and-set-new-ones-as-need.patch
 QTBUG-117950-Fix-XKB_KEY_dead_lowlin
+QTBUG-86285-Fix-kills-all-user-processes
+loongarch.diff


### PR DESCRIPTION
**记录一下分析过程：**
          在测试loong64(3A6000台式机) 桌面环境时发现在x11模式下30秒用户会话被杀掉的问题，然而treeland模式是下是好的(wayland环境下)，看了下系统日志信息用户会话下的进程都被杀死了， 使用bpf跟踪一下signal相关的系统调用(缺少用户态程序，内核缺少相关配置，不得已只能手动编译一套)。 使用bpf监听的结果看是dde-session在给pid -1发送kill 9，找到杀人凶手了但是在代码里没找到相关的行为，准备使用gdb挂一下syscall看一下发现提示不支持(看了眼内核代码发现loongarch64 ptrace下就没支持syscall，不太懂这段代码，放弃修改内核的想法)。只能另想他法了 尝试修改glibc(无效)，尝试修改内核(忽略掉pid 为-1时的相关signal，有效)，修改内核后进桌面不会被30秒倒计时了，这时候开bpf监听发现只要是QT程序就概率性给pid -1发送kill -9 ， 结合前面验证的在treeland模式下没复现到的现象(treeland下的很多程序都切换到了QT6)，这时候看了下这些程序的调用栈都是调用到QT5相关的库(forkfd相关的逻辑)然后才发的signal，对比一下Qt5合Qt6相关的代码发现这段有些许差异，顺着commit记录找到了一个[QTBUG-86285](https://bugreports.qt.io/browse/QTBUG-86285)，该BUG描述的现象跟我们遇到的一样，这个bug在Qt6上得到了修复然而在Qt5分支上游拒绝合入[详见链接](https://codereview.qt-project.org/c/qt/qtbase/+/319522)，合入patch后重新编译Qt5-base后解决, 
deepin仓库中的Qt5-base为添加loongarch64支持，本次合入[链接](https://code.qt.io/cgit/qt/qtbase.git/commit/?id=0ab51dcc3c0cca0d) 
        在这里感谢 @black-desk  @opsiff  @YukariChiba 各位同学的支持