### PR TITLE
forkfd/linux: add support for LoongArch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qtbase-opensource-src (5.15.8-1+deepin5) unstable; urgency=medium
+
+  * add forkfd/linux: add support for LoongArch.
+
+ -- LiChengGang <lichenggang@uniontech.com>  Thu, 29 Feb 2024 15:18:32 +0800
+
 qtbase-opensource-src (5.15.8-1+deepin4) unstable; urgency=medium
 
   * Fix loongarch64 Architecture Avoid doing kill(-1) in QProcess destructor

--- a/debian/patches/loongarch.diff
+++ b/debian/patches/loongarch.diff
@@ -39,3 +39,15 @@ Last-Update: 2024-01-30
  
  /*
      MIPS family, known revisions: I, II, III, IV, 32, 64
+--- qtbase-opensource-src-5.15.8.orig/src/3rdparty/forkfd/forkfd_linux.c
++++ qtbase-opensource-src-5.15.8/src/3rdparty/forkfd/forkfd_linux.c
+@@ -83,7 +83,7 @@ static int sys_clone(unsigned long clone
+ #elif defined(__arc__) || defined(__arm__) || defined(__aarch64__) || defined(__mips__) || \
+     defined(__nds32__) || defined(__hppa__) || defined(__powerpc__) || defined(__i386__) || \
+     defined(__x86_64__) || defined(__xtensa__) || defined(__alpha__) || defined(__riscv) || \
+-    defined(__sw_64__)
++    defined(__sw_64__) || defined(__loongarch__)
+     /* ctid and newtls are inverted on CONFIG_CLONE_BACKWARDS architectures,
+      * but since both values are 0, there's no harm. */
+     return syscall(__NR_clone, cloneflags, child_stack, ptid, ctid, newtls);
+


### PR DESCRIPTION
解决loongarch64环境下process.readAllStandardOutput结果为空的问题