### PR TITLE
fix: QDialog buttons are highlighted incorrectly

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,12 @@
 qtbase-opensource-src (5.15.8-1+deepin6) unstable; urgency=medium
 
+  [ Lu YaNing ]
   * xcb: update xkb_state mask as much as possible
     -- Update-xkb-state-mask-as-much-as-possible.patch
+
+  [ Tian ShiLin ]
+  * Fix Clear WA_UnderMouse attribute when widget gets hidden
+    -- QTBUG-104805-QColorDialog-Buttons-are-highlighted-incorrectly.patch 
 
  -- Lu YaNing <luyaning@uniontech.com>  Fri, 12 Apr 2024 22:35:30 +0800
 

--- a/debian/patches/QTBUG-104805-QColorDialog-Buttons-are-highlighted-incorrectly.patch
+++ b/debian/patches/QTBUG-104805-QColorDialog-Buttons-are-highlighted-incorrectly.patch
@@ -1,0 +1,34 @@
+Author: Tian Shilin <tianshilin@uniontech.com>
+Date:   Thu Apr 18 20:47:00 2023
+Subject: QDialog buttons are highlighted incorrectly
+Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/431809
+
+---
+
+Index: qtbase-opensource-src/src/widgets/kernel/qwidget.cpp
+===================================================================
+--- qtbase-opensource-src.orig/src/widgets/kernel/qwidget.cpp
++++ qtbase-opensource-src/src/widgets/kernel/qwidget.cpp
+@@ -8212,6 +8212,7 @@ void QWidgetPrivate::showChildren(bool s
+ 
+ void QWidgetPrivate::hideChildren(bool spontaneous)
+ {
++    Q_Q(QWidget);
+     QList<QObject*> childList = children;
+     for (int i = 0; i < childList.size(); ++i) {
+         QWidget *widget = qobject_cast<QWidget*>(childList.at(i));
+@@ -8243,6 +8244,14 @@ void QWidgetPrivate::hideChildren(bool s
+         }
+ #endif
+     }
++
++    // If the window of this widget is not closed, then the leave event
++    // will eventually handle the widget under mouse use case.
++    // Otherwise, we need to explicitly handle it here.
++    if (QWidget* widgetWindow = q->window();
++        widgetWindow && widgetWindow->data->is_closing) {
++        q->setAttribute(Qt::WA_UnderMouse, false);
++    }
+ }
+ 
+ bool QWidgetPrivate::close_helper(CloseMode mode)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -68,3 +68,4 @@ QTBUG-117950-Fix-XKB_KEY_dead_lowlin
 QTBUG-86285-Fix-kills-all-user-processes
 loongarch.diff
 Update-xkb-state-mask-as-much-as-possible.patch
+QTBUG-104805-QColorDialog-Buttons-are-highlighted-incorrectly.patch


### PR DESCRIPTION
This patch clears WA_UnderMouse attribute in widget hideChildren() and subsequently, widgets that are hidden will not inherit this attribute on the next show operation. To test flag Qt::X11BypassWindowManagerHint is needed when is_closing=0(e.g. Closing DDialog by Cancel or Ok Bt).

Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/431809