### PR TITLE
fix: xcb: Delete touch points without target windows

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-qtbase-opensource-src (5.15.8-1+deepin7) UNRELEASED; urgency=medium
+qtbase-opensource-src (5.15.8-1+deepin8) unstable; urgency=medium
 
   * Fix Clear WA_UnderMouse attribute when widget gets hidden
     -- QTBUG-104805-QColorDialog-Buttons-are-highlighted-incorrectly.patch
@@ -10,8 +10,10 @@ qtbase-opensource-src (5.15.8-1+deepin7) UNRELEASED; urgency=medium
     -- Fix-QTextEdit-or-QPlanTextEdit-palette-not-updated.patch
   * remove fix_action_distance_lineedit.patch, and allow styles to
     control the margin around icons in QLineEdit.
+  * xcb: Delete touch points without target windows
+    -- Xcb-Delete-touch-points-without-target-windows.patch
 
- -- Tian ShiLin <tiansi@uniontech.com>  Fri, 19 Apr 2024 10:28:01 +0800
+ -- Tian ShiLin <tiansi@uniontech.com>  Fri, 17 May 2024 17:00:44 +0800
 
 qtbase-opensource-src (5.15.8-1+deepin6) unstable; urgency=medium
 

--- a/debian/patches/Xcb-Delete-touch-points-without-target-windows.patch
+++ b/debian/patches/Xcb-Delete-touch-points-without-target-windows.patch
@@ -1,0 +1,110 @@
+Index: qtbase-opensource-src/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp
+===================================================================
+--- qtbase-opensource-src.orig/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp
++++ qtbase-opensource-src/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp
+@@ -591,8 +591,12 @@ void QXcbConnection::xi2HandleEvent(xcb_
+                         event->event_type, xiDeviceEvent->sequence, xiDeviceEvent->detail,
+                         fixed1616ToReal(xiDeviceEvent->event_x), fixed1616ToReal(xiDeviceEvent->event_y),
+                         fixed1616ToReal(xiDeviceEvent->root_x), fixed1616ToReal(xiDeviceEvent->root_y),xiDeviceEvent->event);
+-            if (QXcbWindow *platformWindow = platformWindowFromId(xiDeviceEvent->event))
++            if (QXcbWindow *platformWindow = platformWindowFromId(xiDeviceEvent->event)) {
+                 xi2ProcessTouch(xiDeviceEvent, platformWindow);
++            } else { // When the window cannot be matched, delete it from touchPoints
++                if (TouchDeviceData *dev = touchDeviceForId(xiDeviceEvent->sourceid))
++                    dev->touchPoints.remove((xiDeviceEvent->detail % INT_MAX));
++            }
+             break;
+         }
+     } else if (xiEnterEvent && !xi2MouseEventsDisabled() && eventListener) {
+Index: qtbase-opensource-src/tests/auto/gui/kernel/qwindow/tst_qwindow.cpp
+===================================================================
+--- qtbase-opensource-src.orig/tests/auto/gui/kernel/qwindow/tst_qwindow.cpp
++++ qtbase-opensource-src/tests/auto/gui/kernel/qwindow/tst_qwindow.cpp
+@@ -1113,8 +1113,9 @@ void tst_QWindow::touchToMouseTranslatio
+     QVERIFY(QTest::qWaitForWindowExposed(&window));
+ 
+     QList<QWindowSystemInterface::TouchPoint> points;
+-    QWindowSystemInterface::TouchPoint tp1, tp2;
++    QWindowSystemInterface::TouchPoint tp1, tp2, tp3;
+     const QRectF pressArea(101, 102, 4, 4);
++    const QRectF pressArea1(107, 110, 4, 4);
+     const QRectF moveArea(105, 108, 4, 4);
+     tp1.id = 1;
+     tp1.state = Qt::TouchPointPressed;
+@@ -1122,6 +1123,9 @@ void tst_QWindow::touchToMouseTranslatio
+     tp2.id = 2;
+     tp2.state = Qt::TouchPointPressed;
+     points << tp1 << tp2;
++    tp3.id = 3;
++    tp3.state = Qt::TouchPointPressed;
++    tp3.area = QHighDpi::toNativePixels(pressArea1, &window);
+     QWindowSystemInterface::handleTouchEvent(&window, touchDevice, points);
+     // Now an update but with changed list order. The mouse event should still
+     // be generated from the point with id 1.
+@@ -1194,6 +1198,40 @@ void tst_QWindow::touchToMouseTranslatio
+     points[0].state = Qt::TouchPointReleased;
+     QWindowSystemInterface::handleTouchEvent(&window, touchDevice, points);
+     QCoreApplication::processEvents();
++    points.clear();
++    points.append(tp1);
++    points[0].state = Qt::TouchPointReleased;
++    QWindowSystemInterface::handleTouchEvent(&window, touchDevice, points);
++    QCoreApplication::processEvents();
++    QTRY_COMPARE(window.mouseReleaseButton, 1);
++    
++    points.clear();
++    points.append(tp1);
++    points[0].state = Qt::TouchPointPressed;
++    QWindowSystemInterface::handleTouchEvent(&window, touchDevice, points);
++    QCoreApplication::processEvents();
++    points.clear();
++    points.append(tp2);
++    points[0].state = Qt::TouchPointPressed;
++    QWindowSystemInterface::handleTouchEvent(&window, touchDevice, points);
++    QCoreApplication::processEvents();
++    points.clear();
++    points.append(tp3);
++    points[0].state = Qt::TouchPointPressed;
++    QWindowSystemInterface::handleTouchEvent(&window, touchDevice, points);
++    QCoreApplication::processEvents();
++    QTRY_COMPARE(window.mousePressButton, 1);
++
++    points.clear();
++    points.append(tp2);
++    points[0].state = Qt::TouchPointReleased;
++    QWindowSystemInterface::handleTouchEvent(&window, touchDevice, points);
++    QCoreApplication::processEvents();
++    points.clear();
++    points.append(tp3);
++    points[0].state = Qt::TouchPointReleased;
++    QWindowSystemInterface::handleTouchEvent(&window, touchDevice, points);
++    QCoreApplication::processEvents();
+     points.clear();
+     points.append(tp1);
+     points[0].state = Qt::TouchPointReleased;
+Index: qtbase-opensource-src/tests/auto/widgets/kernel/qgesturerecognizer/tst_qgesturerecognizer.cpp
+===================================================================
+--- qtbase-opensource-src.orig/tests/auto/widgets/kernel/qgesturerecognizer/tst_qgesturerecognizer.cpp
++++ qtbase-opensource-src/tests/auto/widgets/kernel/qgesturerecognizer/tst_qgesturerecognizer.cpp
+@@ -297,7 +297,7 @@ void tst_QGestureRecognizer::swipeGestur
+ 
+     // Press point #3
+     points.append(points.last() + fingerDistance);
+-    swipeSequence.press(points.size() - 1, points.last(), &widget);
++    swipeSequence.stationary(0).stationary(1).press(points.size() - 1, points.last(), &widget);
+     swipeSequence.commit();
+     Q_ASSERT(points.size() == swipePoints);
+ 
+Index: qtbase-opensource-src/src/gui/kernel/qguiapplication.cpp
+===================================================================
+--- qtbase-opensource-src.orig/src/gui/kernel/qguiapplication.cpp
++++ qtbase-opensource-src/src/gui/kernel/qguiapplication.cpp
+@@ -3064,7 +3064,7 @@ void QGuiApplicationPrivate::processTouc
+                 QEvent::Type mouseEventType = QEvent::MouseMove;
+                 Qt::MouseButton button = Qt::NoButton;
+                 Qt::MouseButtons buttons = Qt::LeftButton;
+-                if (eventType == QEvent::TouchBegin && m_fakeMouseSourcePointId < 0)
++                if (eventType == QEvent::TouchBegin || m_fakeMouseSourcePointId < 0)
+                     m_fakeMouseSourcePointId = touchPoints.first().id();
+                 for (const auto &touchPoint : touchPoints) {
+                     if (touchPoint.id() == m_fakeMouseSourcePointId) {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -72,3 +72,4 @@ QTBUG-104805-QColorDialog-Buttons-are-highlighted-incorrectly.patch
 QTBUG-89082-The-previous-tips-is-still-displayed-when-mouse-move-to-another-Action-without-tips.patch
 QMenu-toggle-action-submenu-disappears-immediately.patch
 Fix-QTextEdit-or-QPlanTextEdit-palette-not-updated.patch
+Xcb-Delete-touch-points-without-target-windows.patch


### PR DESCRIPTION
When XCB_INPUT_TOUCH_BEGIN closes a popup, we then receive XCB_INPUT_TOUCH_END, and cannot find a target window (because it's destroyed). If we don't deliver it, we need to at least clear the stored point from QPointingDevicePrivate::activePoints. Then when we deliver the next touch press, m_fakeMouseSourcePointId also needs to be reset.

It's now even more paramount that autotests (and real-world touchscreens) must never omit any active touchpoint from a touch event. If a point doesn't move, it must be included in the QTouchEvent, with Stationary state. If not, QGuiApp::processTouchEvent() could generate multiple TouchBegin events in a row, which gets other bits of logic confused, here and there.

Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/412280