### PR TITLE
Fix CVE-2025-5455: Handle missing charset value in qDecodeDataUrl to …

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+qtbase-opensource-src (5.15.8-1+deepin10) unstable; urgency=medium
+
+  * New upstream release.
+  * fix: Handle missing charset value in qDecodeDataUrl to avoid assertionAdd commentMore actions
+    -- CVE-2025-5455-qtbase-5.15.patch
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Fri, 14 Jun 2025 10:42:24 +0800
+
 qtbase-opensource-src (5.15.8-1+deepin9) unstable; urgency=medium
 
   * fix auto selection for gles

--- a/debian/patches/CVE-2025-5455-qtbase-5.15.patch
+++ b/debian/patches/CVE-2025-5455-qtbase-5.15.patch
@@ -1,0 +1,25 @@
+Author: Tian Shilin<tianshilin@uniontech.com>
+Date:   Fri Jun 14 10:42:24 2025
+Subject:Handle missing charset value in qDecodeDataUrl to avoid assertion
+Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/642006
+
+Index: qtbase-opensource-src/src/corelib/io/qdataurl.cpp
+===================================================================
+--- qtbase-opensource-src.orig/src/corelib/io/qdataurl.cpp
++++ qtbase-opensource-src/src/corelib/io/qdataurl.cpp
+@@ -76,10 +76,11 @@ Q_CORE_EXPORT bool qDecodeDataUrl(const
+         }
+ 
+         if (data.toLower().startsWith("charset")) {
+-            int i = 7;      // strlen("charset")
+-            while (data.at(i) == ' ')
+-                ++i;
+-            if (data.at(i) == '=')
++            int prefixSize = 7; // strlen("charset")
++            QLatin1String copy(data.constData() + prefixSize, data.size() - prefixSize);
++            while (copy.startsWith(QLatin1String(" ")))
++                copy = copy.mid(1);
++            if (copy.startsWith(QLatin1String("=")))
+                 data.prepend("text/plain;");
+         }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -73,3 +73,4 @@ QTBUG-89082-The-previous-tips-is-still-displayed-when-mouse-move-to-another-Acti
 QMenu-toggle-action-submenu-disappears-immediately.patch
 Fix-QTextEdit-or-QPlanTextEdit-palette-not-updated.patch
 Xcb-Delete-touch-points-without-target-windows.patch
+CVE-2025-5455-qtbase-5.15.patch


### PR DESCRIPTION
…avoid assertion

The private function qDecodeDataUrl() in QtCore could trigger an assertion failure when parsing malformed data URLs with a "charset" parameter that lacks a value (e.g., "data:charset,"). This issue affects Qt versions up to 6.8.

This patch applies the fix specifically to Qt 6.8, preventing a denial of service scenario when built with assertions enabled.

Issue: CVE-2025-5455
Upstream:https://codereview.qt-project.org/c/qt/qtbase/+/642006